### PR TITLE
Remove hard-coded Tab key

### DIFF
--- a/contents/ui/main.qml
+++ b/contents/ui/main.qml
@@ -144,7 +144,7 @@ PlasmaCore.Dialog {
         }
         Keys.onReleased: (event) => {
             // mainShortcut.sequence
-            if (event.modifiers === 0 || (event.key !== Qt.Key_Tab && event.key !== Qt.Key_Backtab)) {
+            if (event.modifiers === 0 || event.text.length == 0) {
                 hide();
             }
         }


### PR DESCRIPTION
We want to hide the dialog when the modifier is released. To test that, we can check that the length of the text property of the key event is 0, meaning that it's the modifier key that has been released.

Thanks for saving my workflow by the way...